### PR TITLE
parseXml: Ensure that wires inside signals show up

### DIFF
--- a/www/js/xmlParse.js
+++ b/www/js/xmlParse.js
@@ -950,6 +950,12 @@ function parseXML(theText){
 			// 'signals' holds a signal-line's containing wires, vias, and pads
 			var signals = theBoard.getElementsByTagName('signals')[0];
 			var allSignals = signals.getElementsByTagName('signal');
+			var signalWires = [];
+			Array.from(allSignals).forEach(function(signal) {
+				var wires = Array.from(signal.getElementsByTagName('wire'));
+				signalWires = signalWires.concat(wires);
+			});
+			allWires = Array.from(allWires).concat(signalWires);
 
 			var libraries = theBoard.getElementsByTagName('libraries')[0];
 			var allLibraries = libraries.getElementsByTagName('library');


### PR DESCRIPTION
The example files include with Eagle 7.7.0 are like this